### PR TITLE
An workaround for the include path issue on Mac OS X

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -222,7 +222,9 @@ func! s:DiscoverIncludeDirs(clang, options)
   let l:res = []
   for l:line in l:clang_output
     if l:line[0] == ' '
-      call add(l:res, fnameescape(l:line[1:-1]))
+      " a dirty workaround for Mac OS X (see issue #5)
+      let l:path=substitute(l:line[1:-1], ' (framework directory)$', '', 'g')
+      call add(l:res, fnameescape(l:path))
     elseif l:line =~# '^End'
       break
     endif


### PR DESCRIPTION
In Mac OS X, clang appends an unwanted string '(framework directory)'
at the end of some include directories. This makes the plugin not working.

This workaround patch removes the extra suffix '(framework directory)'
from the include path. It seems a little bit dirty, but it would be
very rare for the include directory to contain it at the end.

See issue #5 for the more details.
