### PR TITLE
add an option to load vim-clang only if .clang file is found

### DIFF
--- a/doc/clang.txt
+++ b/doc/clang.txt
@@ -107,6 +107,12 @@ g:clang_dotfile_overwrite               *g:clang_dotfile_overwrite*
     Default: >
         let g:clang_dotfile_overwrite = '.clang.ow'
 <
+g:clang_load_if_clang_dotfile           g:clang_load_if_clang_dotfile
+        If equals to 1, this plugin will be loaded only if g:clang_dotfile or
+        g:clang_dotfile_overwrite file is found in the at his root.
+    Default: >
+        let g:clang_load_if_clang_dotfile = 0
+
 g:clang_exec                            *g:clang_exec*
         Name or path of executable clang. Use this if clang has a
         non-standard name, or isn't in the path.

--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -35,6 +35,28 @@ if exists('g:clang_loaded')
 endif
 let g:clang_loaded = 1
 
+if !exists('g:clang_load_if_clang_dotfile')
+  let g:clang_load_if_clang_dotfile = 0
+endif
+
+if !exists('g:clang_dotfile')
+  let g:clang_dotfile = '.clang'
+endif
+
+if !exists('g:clang_dotfile_overwrite')
+  let g:clang_dotfile_overwrite = '.clang.ow'
+endif
+
+func! s:isClangFileExists()
+  let l:dotclang    = findfile(g:clang_dotfile, '.;')
+  let l:dotclangow  = findfile(g:clang_dotfile_overwrite, '.;')
+  return strlen(l:dotclang) + strlen(l:dotclangow)
+endf
+
+if ( s:isClangFileExists() == 0 && g:clang_load_if_clang_dotfile == 1 )
+  finish
+endif
+
 if !exists('g:clang_auto')
   let g:clang_auto = 1
 endif
@@ -61,14 +83,6 @@ endif
 
 if !exists('g:clang_diagsopt') || g:clang_diagsopt !~# '^[a-z]\+\(:[0-9]\)\?$'
   let g:clang_diagsopt = 'rightbelow:6'
-endif
-
-if !exists('g:clang_dotfile')
-  let g:clang_dotfile = '.clang'
-endif
-
-if !exists('g:clang_dotfile_overwrite')
-  let g:clang_dotfile_overwrite = '.clang.ow'
 endif
 
 if !exists('g:clang_exec')


### PR DESCRIPTION
User may want continue to use ctags based plugins when he does not have
set a .clang file in its project. When the new option
g:clang_load_if_clang_dotfile is set, it disables the loading of the
vim-clang plugin.

This option searches for g:clang_dotfile and g:clang_dotfile_overwrite
files.
