### PR TITLE
do not initialize plugin for non readable files

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -123,7 +123,7 @@ au FileType c,cpp call <SID>ClangCompleteInit(0)
 "}}}
 "{{{ s:IsValidFile
 func! s:IsValidFile()
-  return &filetype == "c" || &filetype == "cpp"
+  return ( &filetype == "c" || &filetype == "cpp" ) && filereadable(expand("%"))
 endf
 "}}}
 "{{{ s:PDebug


### PR DESCRIPTION
for example, fugitive is using temporary files like fugitive:///myfile.c for Gdiff, Gedit operations
