### PR TITLE
Fix bug in doc for working well with neocomplete

### DIFF
--- a/doc/clang.txt
+++ b/doc/clang.txt
@@ -265,6 +265,7 @@ A: Please use with neocomplete, they can work well together.
         if !exists('g:neocomplete#force_omni_input_patterns')
           let g:neocomplete#force_omni_input_patterns = {}
         endif
+        let g:neocomplete#force_overwrite_completefunc = 1
         
         " for c and c++
         let g:neocomplete#force_omni_input_patterns.c =


### PR DESCRIPTION
Following is the Q&A from neocomplete:

Q: Does not work with clang_complete.

A: Please try below settings.

```
	if !exists('g:neocomplete#force_omni_input_patterns')
	  let g:neocomplete#force_omni_input_patterns = {}
	endif
	let g:neocomplete#force_overwrite_completefunc = 1
	let g:neocomplete#force_omni_input_patterns.c =
	      \ '[^.[:digit:] *\t]\%(\.\|->\)\w*'
	let g:neocomplete#force_omni_input_patterns.cpp =
	      \ '[^.[:digit:] *\t]\%(\.\|->\)\w*\|\h\w*::\w*'
	let g:neocomplete#force_omni_input_patterns.objc =
	      \ '\[\h\w*\s\h\?\|\h\w*\%(\.\|->\)'
	let g:neocomplete#force_omni_input_patterns.objcpp =
	      \ '\[\h\w*\s\h\?\|\h\w*\%(\.\|->\)\|\h\w*::\w*'
	let g:clang_complete_auto = 0
	let g:clang_auto_select = 0
	"let g:clang_use_library = 1
```