### PR TITLE
improve clang-format execution

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -887,7 +887,7 @@ func! s:ClangCompleteInit(force)
   com! ClangSyntaxCheck call <SID>ClangSyntaxCheck(b:clang_root, b:clang_options)
 
   " Useful to format source code
-  com! ClangFormat call <SID>ClangFormat('%')
+  com! ClangFormat call <SID>ClangFormat()
 
   if g:clang_auto   " Auto completion
     inoremap <expr> <buffer> . <SID>CompleteDot()
@@ -1102,9 +1102,11 @@ endf
 " }}}
 " {{{ s:ClangFormat
 " Call clang-format to format source code
-func! s:ClangFormat(file)
-  let l:command = printf("%s -i -style=%s %s", g:clang_format_exec, g:clang_format_style, expand(a:file))
-  call system(l:command)
+func! s:ClangFormat()
+  let l:view = winsaveview()
+  let l:command = printf("%s -style=%s ", g:clang_format_exec, g:clang_format_style)
+  silent execute '%!'. l:command
+  call winrestview(l:view)
 endf
 "}}}
 "{{{ ClangComplete


### PR DESCRIPTION
use [filter command](https://github.com/vim/vim/blob/04dfd512293e951479aec2378753b946c39bea87/runtime/doc/change.txt#L563) instead of clang-format -i (inplace option).

The advantages of this change are below.

- do not need to save file before :ClangFormat (You can also format an unnamed buffer.)
- do not need to reload file after :ClangFormat