### PR TITLE
Add Neomake integration

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -672,6 +672,60 @@ func! s:ParseCompletionResult(output, base)
   return l:res
 endf
 " }}}
+"{{{ s:SetNeomakeMakerArguments
+" Set neomake_{c,cpp}_{clang,gcc}_maker variables to add the Clang arguments
+" parsed from the .clang or .clang.ow files.
+" @clang_options the options to be passed to makers
+func! s:SetNeomakeMakerArguments(clang_options)
+  " Split the arguments into a list
+  let l:clang_options = split(a:clang_options, " ")
+
+  if &filetype == 'cpp'
+
+    if !exists('g:neomake_cpp_clang_maker')
+      let g:neomake_cpp_clang_maker = {
+            \ "args": l:clang_options
+          \}
+    elseif has_key(g:neomake_cpp_clang_maker, "args")
+      call extend(g:neomake_cpp_clang_maker["args"], l:clang_options)
+    else
+      let g:neomake_cpp_clang_maker["args"] = l:clang_options
+    endif
+
+    if !exists('g:neomake_cpp_gcc_maker')
+      let g:neomake_cpp_gcc_maker = {
+            \ "args": l:clang_options
+          \}
+    elseif has_key(g:neomake_cpp_gcc_maker, "args")
+      call extend(g:neomake_cpp_gcc_maker["args"], l:clang_options)
+    else
+      let g:neomake_cpp_gcc_maker["args"] = l:clang_options
+    endif
+
+  elseif &filetype == 'c'
+    if !exists('g:neomake_c_clang_maker')
+      let g:neomake_c_clang_maker = {
+            \ "args": l:clang_options
+          \}
+    elseif has_key(g:neomake_c_clang_maker, "args")
+      call extend(g:neomake_c_clang_maker["args"], l:clang_options)
+    else
+      let g:neomake_c_clang_maker["args"] = l:clang_options
+    endif
+
+    if !exists('g:neomake_c_gcc_maker')
+      let g:neomake_c_gcc_maker = {
+            \ "args": l:clang_options
+          \}
+    elseif has_key(g:neomake_c_gcc_maker, "args")
+      call extend(g:neomake_c_gcc_maker["args"], l:clang_options)
+    else
+      let g:neomake_c_gcc_maker["args"] = l:clang_options
+    endif
+
+  endif
+endf
+"}}}
 "{{{ s:ShrinkPrevieWindow
 " Shrink preview window to fit lines.
 " Assume cursor is in the editing window, and preview window is above of it.
@@ -930,6 +984,9 @@ func! s:ClangCompleteInit(force)
   if g:clang_format_auto
     au BufWritePost <buffer> ClangFormat
   endif
+
+	" Set the configuration variables for Neomake makers
+  call s:SetNeomakeMakerArguments(b:clang_options)
 
   call s:GlobalVarRestore(l:gvars)
 endf

--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -676,7 +676,8 @@ endf
 " Set neomake_{c,cpp}_{clang,gcc}_maker variables to add the Clang arguments
 " parsed from the .clang or .clang.ow files.
 " @clang_options the options to be passed to makers
-func! s:SetNeomakeMakerArguments(clang_options)
+" @clang_root the directory whence the maker must be executed
+func! s:SetNeomakeMakerArguments(clang_options, clang_root)
   " Split the arguments into a list
   let l:clang_options = split(a:clang_options, " ")
 
@@ -691,6 +692,7 @@ func! s:SetNeomakeMakerArguments(clang_options)
     else
       let g:neomake_cpp_clang_maker["args"] = l:clang_options
     endif
+    let g:neomake_cpp_clang_maker["cwd"] = a:clang_root
 
     if !exists('g:neomake_cpp_gcc_maker')
       let g:neomake_cpp_gcc_maker = {
@@ -701,6 +703,7 @@ func! s:SetNeomakeMakerArguments(clang_options)
     else
       let g:neomake_cpp_gcc_maker["args"] = l:clang_options
     endif
+    let g:neomake_cpp_gcc_maker["cwd"] = a:clang_root
 
   elseif &filetype == 'c'
     if !exists('g:neomake_c_clang_maker')
@@ -712,6 +715,7 @@ func! s:SetNeomakeMakerArguments(clang_options)
     else
       let g:neomake_c_clang_maker["args"] = l:clang_options
     endif
+    let g:neomake_c_clang_maker["cwd"] = a:clang_root
 
     if !exists('g:neomake_c_gcc_maker')
       let g:neomake_c_gcc_maker = {
@@ -722,6 +726,7 @@ func! s:SetNeomakeMakerArguments(clang_options)
     else
       let g:neomake_c_gcc_maker["args"] = l:clang_options
     endif
+    let g:neomake_c_gcc_maker["cwd"] = a:clang_root
 
   endif
 endf
@@ -986,7 +991,7 @@ func! s:ClangCompleteInit(force)
   endif
 
 	" Set the configuration variables for Neomake makers
-  call s:SetNeomakeMakerArguments(b:clang_options)
+  call s:SetNeomakeMakerArguments(b:clang_options, b:clang_root)
 
   call s:GlobalVarRestore(l:gvars)
 endf
@@ -1280,4 +1285,4 @@ func! s:ClangComplete(findstart, base)
 endf
 "}}}
 
-" vim: set shiftwidth=2 softtabstop=2 tabstop=2 foldmethod=marker:
+" vim: set shiftwidth=2 softtabstop=2 tabstop=2 expandtab foldmethod=marker:


### PR DESCRIPTION
Add the clang options deduced by vim-clang and parsed from .clang and .clang.ow to Neomake configuration variables for the clang and gcc makers:
- g:neomake_cpp_clang_maker
- g:neomake_cpp_gcc_maker
- g:neomake_c_clang_maker
- g:neomake_cpp_gcc_maker

This makes Neomake use, among other things, the "-I" arguments, and the clang root directory (where the .clang file is located)

It may need some configuration variables to allow customization from user, adding this to the documentation, maybe a more intelligent splitting of the arguments, and some proper testing (so far, it works fine with me)