### PR TITLE
Add python3 support

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -891,6 +891,32 @@ func! s:ClangCompleteDatabase()
 
     call s:PDebug("s:ClangCompleteInit::database", l:ccd)
     if filereadable(l:ccd)
+      if has('python3')
+python3 << endpython
+import vim
+import re
+import json
+
+current = vim.eval("expand('%:p')")
+ccd = vim.eval("l:ccd")
+opts = []
+
+with open(ccd) as database:
+  data = json.load(database)
+
+  for d in data:
+    # hax for headers
+    fmatch = re.search(r'(.*)\.(\w+)$', current)
+    dmatch = re.search(r'(.*)\.(\w+)$', d['file'])
+
+    if fmatch.group(1) == dmatch.group(1):
+      for result in re.finditer(r'-[ID]\s*[^\s]+', d['command']):
+        opts.append(result.group(0))
+      break
+
+vim.command("let l:clang_options = '" + ' '.join(opts) + "'")
+endpython
+      else
 python << endpython
 import vim
 import re
@@ -915,6 +941,7 @@ with open(ccd) as database:
 
 vim.command("let l:clang_options = '" + ' '.join(opts) + "'")
 endpython
+      endif
     endif
   endif
 


### PR DESCRIPTION
If `has('python3')` is 1 and `has('python')` is 0, `ClangCompleteInit` throws exception like `Unknown function: provider#python#Call`.

In `ClangCompleteInit`, `python` command is used, but the executed python script can run on python3.
So, I checked `has('python')` and `has('python3')`, and choose appropriate command to execute python script.

Since I'm beginner of vimscript, python scripts are duplicated on each branch.
If there is more suitable solution, please let me know.
