### PR TITLE
Remove superfluous slash

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -128,7 +128,7 @@ au FileType c,cpp call <SID>ClangCompleteInit(0)
 func! s:IsValidFile()
   let l:cur = expand("%")
   " don't load plugin when in fugitive buffer
-  if l:cur =~ 'fugitive:///'
+  if l:cur =~ 'fugitive://'
     return 0
   endif
   " Please don't use filereadable to test, as the new created file is also


### PR DESCRIPTION
A buffer name of vim-fugitive begins with 'fugitive://' and a path on Windows commonly begins with  'C:\', so 'fugitive:///' doesn't match on Windows ('fugitive://C:/aaa/bbb' !~= 'fugitive:///').