### PR TITLE
Add enable_clang_format_command

### DIFF
--- a/doc/clang.txt
+++ b/doc/clang.txt
@@ -252,6 +252,11 @@ g:clang_compilation_database            *g:clang_compilation_database*
     Default: >
         let g:clang_compilation_database = ''
 <
+g:clang_enable_format_command           *g:clang_enable_format_command*
+        If equals to 1, enable ClangFormat command.
+    Default: >
+        let g:clang_enable_format_command = 1
+<
 ==============================================================================
 COMMANDS                                         *clang-commands*
 

--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -66,8 +66,8 @@ if !exists('g:clang_format_style')
   let g:clang_format_style = 'LLVM'
 end
 
-if !exists('g:enable_clang_format_command')
-  let g:enable_clang_format_command = 1
+if !exists('g:clang_enable_format_command')
+  let g:clang_enable_format_command = 1
 endif
 
 if !exists('g:clang_check_syntax_auto')
@@ -1060,7 +1060,7 @@ func! s:ClangCompleteInit(force)
   " Useful to check syntax only
   com! ClangSyntaxCheck call <SID>ClangSyntaxCheck(b:clang_root, b:clang_options)
 
-  if g:enable_clang_format_command
+  if g:clang_enable_format_command
     " Useful to format source code
     com! ClangFormat call <SID>ClangFormat()
   endif

--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -66,6 +66,10 @@ if !exists('g:clang_format_style')
   let g:clang_format_style = 'LLVM'
 end
 
+if !exists('g:enable_clang_format_command')
+  let g:enable_clang_format_command = 1
+endif
+
 if !exists('g:clang_check_syntax_auto')
 	let g:clang_check_syntax_auto = 0
 endif
@@ -1056,8 +1060,10 @@ func! s:ClangCompleteInit(force)
   " Useful to check syntax only
   com! ClangSyntaxCheck call <SID>ClangSyntaxCheck(b:clang_root, b:clang_options)
 
-  " Useful to format source code
-  com! ClangFormat call <SID>ClangFormat()
+  if g:enable_clang_format_command
+    " Useful to format source code
+    com! ClangFormat call <SID>ClangFormat()
+  endif
 
   if g:clang_auto   " Auto completion
     inoremap <expr> <buffer> . <SID>CompleteDot()


### PR DESCRIPTION
I use ClangFormat command in [vim-clang-format](https://github.com/rhysd/vim-clang-format).
ClangFormat command conflicts between vim-clang and vim-clang-format, and it is inconvenient.
I wrote a code to avoid this problem. so please consider it.