### PR TITLE
Support specific parameters in "g:clang_format_style".

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -1287,7 +1287,7 @@ endf
 " Call clang-format to format source code
 func! s:ClangFormat()
   let l:view = winsaveview()
-  let l:command = printf("%s -style=%s ", g:clang_format_exec, g:clang_format_style)
+  let l:command = printf("%s -style=\"%s\" ", g:clang_format_exec, g:clang_format_style)
   silent execute '%!'. l:command
   call winrestview(l:view)
 endf


### PR DESCRIPTION
Improve the function `ClangFormat` to support specific parameters in clang format style, solving the issue #91. For example, the following configuration is not supported:

```
{BasedOnStyle: Google, IndentWidth: 4, TabWidth: 4, Standard: Cpp11}
```

The support for specific parameters is an important feature of clang-format. Now, we can set `g:clang_format_style` in `.vimrc` as the following:

```
let g:clang_format_style='{BasedOnStyle: Google, IndentWidth: 4, TabWidth: 4, Standard: Cpp11}'
```