### PR TITLE
Use augroup to bundle autocmds

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -125,7 +125,10 @@ if !exists('g:clang_verbose_pmenu')
 endif
 
 " Init on c/c++ files
-au FileType c,cpp call <SID>ClangCompleteInit(0)
+aug vim-clang
+  au!
+  au FileType c,cpp call <SID>ClangCompleteInit(0)
+aug END
 "}}}
 "{{{ s:IsValidFile
 " A new file is also a valid file
@@ -1073,35 +1076,39 @@ func! s:ClangCompleteInit(force)
     endif
   endif
 
-  " CompleteDone event is available since version 7.3.598
-  if exists("##CompleteDone")
-    au CompleteDone <buffer> call <SID>PDebug("##CompleteDone", "triggered")
-    " Automatically resize preview window after completion.
-    " Default assume preview window is above of the editing window.
-    au CompleteDone <buffer> call <SID>ShrinkPrevieWindow()
-  else
-    let b:clang_isCompleteDone_0 = 0
-    au CursorMovedI <buffer>
-          \ if b:clang_isCompleteDone_0 |
-          \   call <SID>ShrinkPrevieWindow() |
-          \   let b:clang_isCompleteDone_0 = 0 |
-          \ endif
-  endif
+  aug vim-clang
+    au! * <buffer>
 
-  au BufUnload <buffer> call <SID>DiagnosticsPreviewWindowCloseWhenLeave()
+    " CompleteDone event is available since version 7.3.598
+    if exists("##CompleteDone")
+      au CompleteDone <buffer> call <SID>PDebug("##CompleteDone", "triggered")
+      " Automatically resize preview window after completion.
+      " Default assume preview window is above of the editing window.
+      au CompleteDone <buffer> call <SID>ShrinkPrevieWindow()
+    else
+      let b:clang_isCompleteDone_0 = 0
+      au CursorMovedI <buffer>
+            \ if b:clang_isCompleteDone_0 |
+            \   call <SID>ShrinkPrevieWindow() |
+            \   let b:clang_isCompleteDone_0 = 0 |
+            \ endif
+    endif
 
-  au BufEnter <buffer> call <SID>BufVarSet()
-  au BufLeave <buffer> call <SID>BufVarRestore()
+    au BufUnload <buffer> call <SID>DiagnosticsPreviewWindowCloseWhenLeave()
 
-  " auto check syntax when write buffer
-	if g:clang_check_syntax_auto
-		au BufWritePost <buffer> ClangSyntaxCheck
-	endif
+    au BufEnter <buffer> call <SID>BufVarSet()
+    au BufLeave <buffer> call <SID>BufVarRestore()
 
-  " auto format current file if is enabled
-  if g:clang_format_auto
-    au BufWritePost <buffer> ClangFormat
-  endif
+    " auto check syntax when write buffer
+    if g:clang_check_syntax_auto
+      au BufWritePost <buffer> ClangSyntaxCheck
+    endif
+
+    " auto format current file if is enabled
+    if g:clang_format_auto
+      au BufWritePost <buffer> ClangFormat
+    endif
+  aug END
 
   if exists(":Neomake")
     " Set the configuration variables for Neomake makers


### PR DESCRIPTION
It is a better way to handle autocmds associated with vim-clang.
