### PR TITLE
Set clang_vim_exec to 'gvim' when running gvim in Linux

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -115,6 +115,8 @@ endif
 if !exists('g:clang_vim_exec')
   if has('mac')
     let g:clang_vim_exec = 'mvim'
+  elseif !g:clang_has_win && has('gui_running')
+    let g:clang_vim_exec = 'gvim'
   else
     let g:clang_vim_exec = 'vim'
   endif


### PR DESCRIPTION
Following #114 