### PR TITLE
Fix broken compilation_database support and working directories

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -946,7 +946,7 @@ func! s:ClangCompleteInit(force)
   if l:localdir
     silent exe 'lcd ' . l:cwd
   else
-    silent exe 'cd '. fnameescape(getcwd(-1))
+    silent exe 'cd ' . l:cwd
   end
 
   let l:has_dotclang = strlen(l:dotclang) + strlen(l:dotclangow)
@@ -1045,7 +1045,7 @@ func! s:ClangCompleteInit(force)
     if l:localdir
       silent exe 'lcd ' . l:cwd
     else
-      silent exe 'cd ' . fnameescape(getcwd(-1))
+      silent exe 'cd ' . l:cwd
     end
   endif
 
@@ -1233,7 +1233,7 @@ func! s:ClangExecute(root, clang_options, line, col)
   if l:localdir
     silent exe 'lcd ' . l:cwd
   else
-    silent exe 'cd ' . fnameescape(getcwd(-1))
+    silent exe 'cd ' . l:cwd
   end
   let b:clang_state['stdout'] = l:res[0]
   let b:clang_state['stderr'] = l:res[1]
@@ -1290,7 +1290,7 @@ func! s:ClangSyntaxCheck(root, clang_options)
   if l:localdir
     silent exe 'lcd ' . l:cwd
   else
-    silent exe 'cd ' . fnameescape(getcwd(-1))
+    silent exe 'cd ' . l:cwd
   end
 endf
 " }}}

--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -903,7 +903,7 @@ func! s:ClangCompleteDatabase()
 
   if g:clang_compilation_database !=# ''
     let l:ccd = fnameescape(fnamemodify(
-          \ g:clang_compilation_database . '/compile_commands.json', '%:p'))
+          \ g:clang_compilation_database, '%:p'))
     let b:clang_root = fnameescape(fnamemodify(
           \ g:clang_compilation_database, ':p:h'))
 

--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -941,8 +941,8 @@ func! s:ClangCompleteInit(force)
   let l:cwd = fnameescape(getcwd())
   let l:fwd = fnameescape(expand('%:p:h'))
   silent exe 'lcd ' . l:fwd
-  let l:dotclang    = findfile(g:clang_dotfile, '.;')
-  let l:dotclangow  = findfile(g:clang_dotfile_overwrite, '.;')
+  let l:dotclang    = fnamemodify(findfile(g:clang_dotfile, '.;'), ':p')
+  let l:dotclangow  = fnamemodify(findfile(g:clang_dotfile_overwrite, '.;'), ':p')
   if l:localdir
     silent exe 'lcd ' . l:cwd
   else

--- a/plugin/compilation_database.py
+++ b/plugin/compilation_database.py
@@ -18,8 +18,8 @@ def get_entry_by_filename(entries, fn, key=None):
 
     return None
 
-def find_entry(entries, fn):
-    """Find an entry that matches the given filename fn more or less."""
+def find_entry(entries, curr_file):
+    """Find an entry that matches the given filename curr_file more or less."""
 
     entry = get_entry_by_filename(entries, curr_file)
     if entry is not None:


### PR DESCRIPTION
This pull request has 3 parts:

- fix the working directory reset for windows using global working directories
  - We often switch to the file's local directory after which we want to return to the old working directory
  - currently, we instead set the global working directory to the user's home

- make sure that the .clang file we find is converted to absolute path
  - we use findfile to find the .clang.
  - findfile returns an absolute path UNLESS the file is in the current directory
  - as a result, if the .clang file is in the same directory as our code file, but a different one than the current working directory, we end up failing to find the .clang file after returning to the old working directory
  - to fix this, we simply always convert the .clang file to an absolute path

- fix compilation database support
  - there is a bug in the .py file going back 2 years where we use the wrong argument name (meaning compilation database support didn't work for at least 2 years!)
  - in addition, there is a bug where we append the "compile_commands.json" filename to the compilation database filename, resulting in double the filename.

I'm currently using this fix and it works! :D