### PR TITLE
Since vim 8.2.2426,7 changing windows not allowed in complete function

### DIFF
--- a/plugin/clang.vim
+++ b/plugin/clang.vim
@@ -856,15 +856,22 @@ func! s:SetNeomakeMakerArguments(clang_options, clang_root)
   endif
 endf
 "}}}
-"{{{ s:ShrinkPrevieWindow
+"{{{ s:OpenDiagAndShrinkPreviewWindow
 " Shrink preview window to fit lines.
 " Assume cursor is in the editing window, and preview window is above of it.
 " Global variable
 "   g:clang_pwheight
 "   g:clang_statusline
-func! s:ShrinkPrevieWindow()
+func! s:OpenDiagAndShrinkPreviewWindow()
   if &completeopt !~ 'preview'
     return
+  endif
+
+  " call to show diagnostics
+  if exists('b:clang_cache') && exists('b:clang_state')
+    if ! empty(b:clang_cache['diagnostics']) && b:clang_state['state'] == 'ready'
+      call <SID>DiagnosticsWindowOpen(expand('%:p:.'), b:clang_cache['diagnostics'])
+    endif
   endif
 
   "current view
@@ -882,7 +889,7 @@ func! s:ShrinkPrevieWindow()
     endif
     let l:height = min([line('$'), g:clang_pwheight])
     exe 'resize ' . l:height
-    call s:PDebug("s:ShrinkPrevieWindow::height", l:height)
+    call s:PDebug("s:OpenDiagAndShrinkPreviewWindow::height", l:height)
     if l:cft != &filetype
       exe 'set filetype=' . l:cft
       setl nobuflisted
@@ -1092,12 +1099,12 @@ func! s:ClangCompleteInit(force)
     au CompleteDone <buffer> call <SID>PDebug("##CompleteDone", "triggered")
     " Automatically resize preview window after completion.
     " Default assume preview window is above of the editing window.
-    au CompleteDone <buffer> call <SID>ShrinkPrevieWindow()
+    au CompleteDone <buffer> call <SID>OpenDiagAndShrinkPreviewWindow()
   else
     let b:clang_isCompleteDone_0 = 0
     au CursorMovedI <buffer>
           \ if b:clang_isCompleteDone_0 |
-          \   call <SID>ShrinkPrevieWindow() |
+          \   call <SID>OpenDiagAndShrinkPreviewWindow() |
           \   let b:clang_isCompleteDone_0 = 0 |
           \ endif
   endif
@@ -1404,11 +1411,10 @@ func! s:ClangComplete(findstart, base)
     let b:clang_cache['completions'] = s:ParseCompletionResult(b:clang_state['stdout'], l:base)
     " close preview window if empty or has no preview window above, may above
     " other windows...
-    if empty(b:clang_cache['completions']) || !s:HasPreviewAbove()
+    " since vim 8.2.2486 cannot change windows in completefunc -
+    if !has("patch-8.2.2426") && (empty(b:clang_cache['completions']) || !s:HasPreviewAbove())
       pclose
     endif
-    " call to show diagnostics
-    call s:DiagnosticsWindowOpen(expand('%:p:.'), b:clang_cache['diagnostics'])
     return l:start
   else
     call s:PDebug("ClangComplete", "phase 2")


### PR DESCRIPTION
@justmao945 hi,
Thank you for this awesome plugin.

Here is an update needed since vim changes in 8.2.2426, 7
Not sure if there are better things to check/do other than just skipping these ?

Without this I get many -
Error detected while processing function ClangComplete[2]..<SNR>31_ClangComplete[62]..<SNR>31_HasPreviewAbove:
E565: Not allowed to change text or change window

thx,
-m